### PR TITLE
replaced deprecated call_func() with call()

### DIFF
--- a/addons/protobuf/parser.gd
+++ b/addons/protobuf/parser.gd
@@ -1177,9 +1177,8 @@ class Analysis:
 				public = true
 			offset += 1
 		var f_name : String = path_dir + get_text_from_token(indexed_tokens[offset].token)
-		var file : File = File.new()
-		var sha : String = file.get_sha256(f_name)
-		if file.file_exists(f_name):
+		var sha : String = FileAccess.get_sha256(f_name)
+		if FileAccess.file_exists(f_name):
 			for i in import_table:
 				if i.path == f_name:
 					result.success = false
@@ -2017,19 +2016,19 @@ class Translator:
 		return text
 	
 	func translate(file_name : String, core_file_name : String) -> bool:
-		var file : File = File.new()
-		if file.open(file_name, File.WRITE) < 0:
+		var file = FileAccess.open(file_name, FileAccess.WRITE)
+		if file == null:
 			printerr("File: '", file_name, "' save error.")
 			return false
-		var core_file : File = File.new()
-		if !core_file.file_exists(core_file_name):
+		if !FileAccess.file_exists(core_file_name):
 			printerr("File: '", core_file_name, "' not found.")
 			return false
-		if core_file.open(core_file_name, File.READ) < 0:
+		var core_file = FileAccess.open(core_file_name, FileAccess.READ)
+		if core_file == null:
 			printerr("File: '", core_file_name, "' read error.")
 			return false
-		var core_text : String = core_file.get_as_text()
-		core_file.close()
+		var core_text = core_file.get_as_text()
+		core_file = null
 		var text : String = ""
 		var nesting : int = 0
 		text += core_text + "\n\n\n"
@@ -2048,8 +2047,8 @@ class Translator:
 		text += cls_user
 		text += "################ USER DATA END #################\n"
 		file.store_string(text)
-		file.close()
-		if !file.file_exists(file_name):
+		file = null
+		if !FileAccess.file_exists(file_name):
 			printerr("File: '", file_name, "' save error.")
 			return false
 		return true
@@ -2066,16 +2065,16 @@ class ImportFile:
 	var parent_index : int
 
 func parse_all(analyzes : Dictionary, imports : Array, path : String, full_name : String, parent_index : int) -> bool:
-	var file : File = File.new()
-	if !file.file_exists(full_name):
+	if !FileAccess.file_exists(full_name):
 		printerr(full_name, ": not found.")
 		return false
-	if file.open(full_name, File.READ) < 0:
+	var file = FileAccess.open(full_name, FileAccess.READ)
+	if file == null:
 		printerr(full_name, ": read error.")
 		return false
 	var doc : Document = Document.new(full_name, file.get_as_text())
 	var sha : String = file.get_sha256(full_name)
-	file.close()
+	file = null
 	if !analyzes.has(sha):
 		print(full_name, ": parsing.")
 		var analysis : Analysis = Analysis.new(path, doc)

--- a/addons/protobuf/protobuf_cmdln.gd
+++ b/addons/protobuf/protobuf_cmdln.gd
@@ -52,8 +52,8 @@ func _init():
 	var input_file_name = arguments["input"]
 	var output_file_name = arguments["output"]
 
-	var file = File.new()
-	if file.open(input_file_name, File.READ) < 0:
+	var file = FileAccess.open(input_file_name, FileAccess.READ)
+	if file == null:
 		error("File: '" + input_file_name + "' not found.")
 
 	var parser = Parser.new()

--- a/addons/protobuf/protobuf_core.gd
+++ b/addons/protobuf/protobuf_core.gd
@@ -470,7 +470,7 @@ class PBPacker:
 						if inner_size + offset > bytes.size():
 							return PB_ERR.LENGTHDEL_SIZE_MISMATCH
 						if message_func_ref != null:
-							var message = message_func_ref.call_func()
+							var message = message_func_ref.call()
 							if inner_size > 0:
 								var sub_offset = message.from_bytes(bytes, offset, inner_size + offset)
 								if sub_offset > 0:

--- a/addons/protobuf/protobuf_ui_dock.gd
+++ b/addons/protobuf/protobuf_ui_dock.gd
@@ -59,8 +59,8 @@ func _on_CompileButton_pressed():
 		$FilesErrorAcceptDialog.popup_centered()
 		return
 	
-	var file = File.new()
-	if file.open(input_file_name, File.READ) < 0:
+	var file = FileAccess.open(input_file_name, FileAccess.READ)
+	if file == null:
 		print("File: '", input_file_name, "' not found.")
 		$FailAcceptDialog.popup_centered()
 		return
@@ -78,15 +78,14 @@ func _on_CompileButton_pressed():
 func execute_unit_tests(source_name, script_name, compiled_script_name):
 	
 	var test_path = "res://addons/protobuf/test/"
-	var test_file = File.new()
 	var input_file_path = test_path + "source/" + source_name
 	var output_dir_path = test_path + "temp"
 	var output_file_path = output_dir_path + "/" + compiled_script_name
 	
-	var output_dir = Directory.new();
+	var output_dir = DirAccess.new();
 	output_dir.make_dir(output_dir_path)
-	
-	if test_file.open(input_file_path, File.READ) < 0:
+	var test_file = FileAccess.open(input_file_path, FileAccess.READ)
+	if test_file == null:
 		print("File: '", input_file_path, "' not found.")
 		$FailAcceptDialog.popup_centered()
 		return
@@ -102,7 +101,7 @@ func execute_unit_tests(source_name, script_name, compiled_script_name):
 	else:
 		$FailAcceptDialog.popup_centered()
 	
-	test_file.close()
+	test_file = null
 	
 	return
 


### PR DESCRIPTION
I believe the `call_func()` method has been replaced with the `call()` method in GDScript 2.0, as per https://docs.godotengine.org/en/latest/classes/class_callable.html#class-callable-method-call

This seems to be working for me. 